### PR TITLE
Replace env values from Okteto secrets

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -21,14 +21,14 @@ spec:
         - name: PORT
           value: "8080"
         - name: ProxySite
-          value: "mirror.umd.edu"
+          value: "$ProxySite"
         - name: Vless_UUID
-          value: "5c301bb8-6c77-41a0-a606-4ba11bbab084"
+          value: "$Vless_UUID"
         - name: Vless_Path
-          value: "/s233"
+          value: "$Vless_Path"
         - name: Vmess_UUID
-          value: "5c301bb8-6c77-41a0-a606-4ba11bbab084"
+          value: "$Vmess_UUID"
         - name: Vmess_Path
-          value: "/s244"
+          value: "$Vmess_Path"
         - name: Share_Path
-          value: "/share233"
+          value: "$Share_Path"

--- a/okteto-pipeline.yml
+++ b/okteto-pipeline.yml
@@ -1,3 +1,4 @@
 deploy:
   - okteto build -t okteto.dev/ray:latest
-  - kubectl apply -f k8s
+  - kubectl apply -f k8s/service.yml
+  - envsubst < k8s/deployment.yaml | kubectl apply -f -


### PR DESCRIPTION
Okteto Secrets are automatically injected in your Okteto Pipeline as environment variables.
Thus can use envsubst to replace env values from environment variables.
If Okteto secrets is not defined, value will be empty, which will use the default from entrypoint.sh